### PR TITLE
他プロジェクトのバージョンを表示できなかった問題を修正

### DIFF
--- a/lib/ref_issue.rb
+++ b/lib/ref_issue.rb
@@ -168,11 +168,16 @@ module WikiListsRefIssue
               version_id = $2
               middle = $3
               tail = $4
-              version = @project.versions.find_by_id(version_id.to_i)
-              new_block = head + version_id + middle
-              new_block << "&nbsp;" + version.effective_date.to_s
-              new_block << "&nbsp;" + version.description + tail
-              new_block # replace
+              version = Version.visible.find_by_id(version_id.to_i)
+              if version
+                new_block = head + version_id + middle
+                new_block << "&nbsp;" + version.effective_date.to_s if version.effective_date
+                new_block << "&nbsp;" + version.description if version.description
+                new_block << tail
+                new_block # replace
+              else
+                version_tr_block # do not replace
+              end
             else
               version_tr_block # do not replace
             end

--- a/lib/ref_issue.rb
+++ b/lib/ref_issue.rb
@@ -169,10 +169,10 @@ module WikiListsRefIssue
               middle = $3
               tail = $4
               version = Version.visible.find_by_id(version_id.to_i)
-              if version
+              if version.present?
                 new_block = head + version_id + middle
-                new_block << "&nbsp;" + version.effective_date.to_s if version.effective_date
-                new_block << "&nbsp;" + version.description if version.description
+                new_block << "&nbsp;" + version.effective_date.to_s if version.effective_date.present?
+                new_block << "&nbsp;" + version.description if version.description.present?
                 new_block << tail
                 new_block # replace
               else


### PR DESCRIPTION
他プロジェクトのバージョンを表示出来なかった問題を修正し、もしバージョンやその中の情報が取得出来なかった場合には表示しないことでエラーを回避するようにしました
